### PR TITLE
通知とルーム一覧の改善

### DIFF
--- a/app/assets/stylesheets/modules/_tweet-index.scss
+++ b/app/assets/stylesheets/modules/_tweet-index.scss
@@ -2,7 +2,7 @@
   width: 460px;
   margin: 0px auto;
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   flex-wrap: wrap;
   @include lg{
     width: 1000px;

--- a/app/views/activities/_activity.html.haml
+++ b/app/views/activities/_activity.html.haml
@@ -35,7 +35,7 @@
             = activity.tweet.user.nickname + 'さんの投稿'
         にコメントしました
       .notification-top__items__item--message
-        = Comment.find_by(id: activity.comment_id)&.content
+        = truncate(Comment.find_by(id: activity.comment_id)&.content, length: 20)
       .notification-top__items__item--date
         = time_ago_in_words(activity.created_at).upcase
 
@@ -49,7 +49,7 @@
           = visited.nickname
         さんにメッセージを送信しました
       .notification-top__items__item--message
-        = Message.find_by(id: activity.message_id)&.message
+        = truncate(Message.find_by(id: activity.message_id)&.message, length: 20)
       .notification-top__items__item--date
         = time_ago_in_words(activity.created_at).upcase
 

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -33,7 +33,7 @@
             = notification.tweet.user.nickname + 'さんの投稿'
         にコメントしました
       .notification-top__items__item--message
-        = Comment.find_by(id: notification.comment_id)&.content
+        = truncate(Comment.find_by(id: notification.comment_id)&.content, length: 20)
       .notification-top__items__item--date
         = time_ago_in_words(notification.created_at).upcase
   - when 'message'
@@ -46,7 +46,7 @@
           = visitor.nickname
         さんがあなたにメッセージを送信しました
       .notification-top__items__item--message
-        = Message.find_by(id: notification.message_id)&.message
+        = truncate(Message.find_by(id: notification.message_id)&.message, length: 20)
       .notification-top__items__item--date
         = time_ago_in_words(notification.created_at).upcase
   - when 'follow'

--- a/app/views/rooms/_room.html.haml
+++ b/app/views/rooms/_room.html.haml
@@ -9,6 +9,7 @@
         = user.nickname
       - if message.present?
         .room-index__items__item__content--message
-          = message.message
+          = truncate(message.message, length: 20)
+          -# = message.message
         .room-index__items__item__content--date
           = message.created_at.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
通知とルーム一覧ページで、
メッセージとコメントの最大表示文字数を20文字に制限しました。